### PR TITLE
Use safer variable check

### DIFF
--- a/src/compile.env.darwin
+++ b/src/compile.env.darwin
@@ -1,4 +1,4 @@
-if [ -z "$BOSH_PACKAGES_DIR" ]; then
+if [ -z "${BOSH_PACKAGES_DIR:-}" ]; then
   export GOROOT=$(readlink -nf /var/vcap/packages/golang-1.8-darwin)
 else
   export GOROOT=$BOSH_PACKAGES_DIR/golang-1.8-darwin

--- a/src/compile.env.generic
+++ b/src/compile.env.generic
@@ -1,6 +1,6 @@
 platform=`uname | tr '[:upper:]' '[:lower:]'`
 
-if [ -z "$BOSH_PACKAGES_DIR" ]; then
+if [ -z "${BOSH_PACKAGES_DIR:-}" ]; then
   export GOROOT=$(readlink -nf /var/vcap/packages/golang-1.8-${platform})
 else
   export GOROOT=$BOSH_PACKAGES_DIR/golang-1.8-${platform}

--- a/src/compile.env.linux
+++ b/src/compile.env.linux
@@ -1,4 +1,4 @@
-if [ -z "$BOSH_PACKAGES_DIR" ]; then
+if [ -z "${BOSH_PACKAGES_DIR:-}" ]; then
   export GOROOT=$(readlink -nf /var/vcap/packages/golang-1.8-linux)
 else
   export GOROOT=$BOSH_PACKAGES_DIR/golang-1.8-linux


### PR DESCRIPTION
Avoids "unbound variable" errors if packaging scripts are using -u

```
Task 25105 | 09:36:07 | Compiling packages: ssoca-clients/e8e52b81d0e6795bc814dd50a7d22de20bb432c2 (00:02:44)
                     L Error: Action Failed get_task: Task e3a93edb-aa80-40c3-7853-9c6d438940de result: Compiling package ssoca-clients: Running packaging script: Running packaging script: Command exited with 1; Stdout: , Stderr: ++ ls ssoca-clients
+ [[ '' != '' ]]
+ mkdir -p gopath/src/github.com/dpb587
+ mv ssoca gopath/src/github.com/dpb587/ssoca
+ cd gopath
+ source /var/vcap/packages/golang-1.8-linux/bosh/compile.env
/var/vcap/packages/golang-1.8-linux/bosh/compile.env: line 1: BOSH_PACKAGES_DIR: unbound variable
```

Untested