### PR TITLE
Set GOCACHE so it easier to use go modules

### DIFF
--- a/src/1.11/compile.env.darwin
+++ b/src/1.11/compile.env.darwin
@@ -5,4 +5,5 @@ else
 fi
 
 export GOPATH=$PWD
+export GOCACHE=$PWD
 export PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/src/1.11/compile.env.generic
+++ b/src/1.11/compile.env.generic
@@ -7,4 +7,5 @@ else
 fi
 
 export GOPATH=$PWD
+export GOCACHE=$PWD
 export PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/src/1.11/compile.env.linux
+++ b/src/1.11/compile.env.linux
@@ -5,4 +5,5 @@ else
 fi
 
 export GOPATH=$PWD
+export GOCACHE=$PWD
 export PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/src/1.11/compile.env.windows
+++ b/src/1.11/compile.env.windows
@@ -7,6 +7,7 @@ try {
   }
 
   $env:GOPATH="${PWD}"
+  $env:GOCACHE="${PWD}"
   $env:PATH="${env:GOROOT}\bin;${env:GOPATH}\bin;${env:PATH}"
   Exit 1
 } catch {

--- a/src/1.11/runtime.env.linux
+++ b/src/1.11/runtime.env.linux
@@ -1,3 +1,4 @@
 export GOROOT=$(readlink -nf /var/vcap/packages/golang-1.11-linux)
 export GOPATH="${PWD}"
 export PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"
+export GOCACHE=$PWD

--- a/src/1.11/runtime.env.windows
+++ b/src/1.11/runtime.env.windows
@@ -1,6 +1,7 @@
 try {
   $env:GOROOT="C:\var\vcap\packages\golang-1.11-windows\go"
   $env:GOPATH="${PWD}"
+  $env:GOCACHE="${PWD}"
   $env:PATH="${env:GOROOT}\bin;${env:GOPATH}\bin;${env:PATH}"
 } catch {
   Write-Error $_.Exception.Message

--- a/src/1/compile.env.darwin
+++ b/src/1/compile.env.darwin
@@ -5,4 +5,5 @@ else
 fi
 
 export GOPATH=$PWD
+export GOCACHE=$PWD
 export PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/src/1/compile.env.generic
+++ b/src/1/compile.env.generic
@@ -7,4 +7,5 @@ else
 fi
 
 export GOPATH=$PWD
+export GOCACHE=$PWD
 export PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/src/1/compile.env.linux
+++ b/src/1/compile.env.linux
@@ -5,4 +5,5 @@ else
 fi
 
 export GOPATH=$PWD
+export GOCACHE=$PWD
 export PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/src/1/compile.env.windows
+++ b/src/1/compile.env.windows
@@ -7,6 +7,7 @@ try {
   }
 
   $env:GOPATH="${PWD}"
+  $env:GOCACHE="${PWD}"
   $env:PATH="${env:GOROOT}\bin;${env:GOPATH}\bin;${env:PATH}"
   Exit 1
 } catch {

--- a/src/1/runtime.env.linux
+++ b/src/1/runtime.env.linux
@@ -1,3 +1,4 @@
 export GOROOT=$(readlink -nf /var/vcap/packages/golang-1-linux)
 export GOPATH="${PWD}"
+export GOCACHE="${PWD}"
 export PATH="${GOROOT}/bin:${GOPATH}/bin:${PATH}"

--- a/src/1/runtime.env.windows
+++ b/src/1/runtime.env.windows
@@ -1,6 +1,7 @@
 try {
   $env:GOROOT="C:\var\vcap\packages\golang-1-windows\go"
   $env:GOPATH="${PWD}"
+  $env:GOCACHE="${PWD}"
   $env:PATH="${env:GOROOT}\bin;${env:GOPATH}\bin;${env:PATH}"
 } catch {
   Write-Error $_.Exception.Message


### PR DESCRIPTION
[Go modules](https://github.com/golang/go/wiki/Modules) require GOCACHE directory to be set.
It is up to release author how they set go.mod and if they want to use `GO111MODULE=on`. 
It is impossible to enable go.mod inside GOPATH and keep original way working.

PS. I can provide tests if required.