### PR TITLE
Add the ability to extract package version

### DIFF
--- a/scripts/get-package-version.sh
+++ b/scripts/get-package-version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+dir="$(dirname $0)"
+
+cd "${dir}"
+git log -S  "${1}" --format=format:%H | head -1 | xargs -I {} git show {}:"packages/${2}/version"


### PR DESCRIPTION
This script will add the ability to extract package version by passing in the SHA for spec.lock. Users of this release often time have a hard time telling which version of GO is used under the release. Teams have came up with creative solutions (e.g. adding a document when bumping this package), but those solution can fall out of date when a commit is reverted. This script will print out the GO_VERSION used within that package.

We planned on adding this script to our CI scripts so that we can explicitly tell what version of GO is running for a given release and ensure the version is the same as the dockerfile it's running under. I felt that maybe this script is more useful if it's under this release instead of being hidden away from most folks.

example usage: `./scripts/get-package-version.sh 8c04109541f4d504f5be559da433998bd459b0f45cd3654557cc3642cc4d2f60 golang-1.19-windows`