### PR TITLE
docs: Adjust the documentation after the org migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Note: requires bosh-cli version `v2.0.36`+ to `vendor-package` and `create-relea
 To vendor golang package into your release, run:
 
 ```
-$ git clone https://github.com/bosh-packages/golang-release
+$ git clone https://github.com/cloudfoundry/bosh-package-golang-release
 $ cd ~/workspace/your-release
-$ bosh vendor-package golang-1.20-linux ~/workspace/golang-release
+$ bosh vendor-package golang-1.20-linux ~/workspace/bosh-package-golang-release
 ```
 
 Included packages:


### PR DESCRIPTION
Hi community,

as far as I know, you did an [org migration](https://github.com/cloudfoundry/community/pull/512) and missed adjusting the documentation/ Concourse pipeline definitions/ bash scripts. Anyway, this PR will adjust the appropriate documentation to resolve the possible issues.

Pascal