### PR TITLE
fix: always use the local tool-chain

### DIFF
--- a/src/compile.env.unix
+++ b/src/compile.env.unix
@@ -6,4 +6,5 @@ fi
 
 export GOPATH=$PWD
 export GOCACHE=/var/vcap/data/${PACKAGE_NAME}/cache
+export GOTOOLCHAIN=local
 export PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/src/compile.env.windows
+++ b/src/compile.env.windows
@@ -7,6 +7,7 @@ try {
   }
 
   $env:GOPATH="${PWD}"
+  $env:GOTOOLCHAIN="local"
   $env:GOCACHE="C:\var\vcap\data\${PACKAGE_NAME}\cache"
   $env:PATH="${env:GOROOT}\bin;${env:GOPATH}\bin;${env:PATH}"
   Exit 1


### PR DESCRIPTION
Starting with go1.21 the go command will automatically download the appropriate version of the go tool-chain in case the currently executing tool-chain is not compatible with the module that is being built.

Since we build releases as self-contained packages that should not require a internet connection to function this commit disables that behaviour by setting `GOTOOLCHAIN=local` in the compile env. If the tool-chain is unable to compile the module, it will fail as it was the case with pre-go1.21 versions.

See: https://go.dev/doc/toolchain