### PR TITLE
Enable the CI task `bump-golang-package` to remove packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The `bump-golang-package` task runs `bosh vendor-package` to automatically updat
 * `GIT_USER_NAME`: Required. The email that will be used to generate commits.
 * `GIT_USER_EMAIL`: Required. The user name that will be used to generate commits.
 * `PACKAGES`: Required. Specifies Golang packages will be vendored into your own BOSH release, e.g. the `golang-1-linux` package.
+* `PACKAGES_TO_REMOVE`: Optional. A list of packages to remove from the release. This can be useful if one is bumping from `golang-1.x-linux` to `golang-1.y-linux` and `1.y` is intended to replace `1.x`/
 * `PRIVATE_YML`: Required. The contents of config/private.yml for your own BOSH release. Necessary to run `bosh vendor-package`.
 * `RELEASE_DIR`: Required. The directory where your release has been cloned on disk.
 

--- a/ci/tasks/shared/bump-golang-package.sh
+++ b/ci/tasks/shared/bump-golang-package.sh
@@ -12,6 +12,10 @@ git clone input_repo "$repo_output"
 
 cd "$repo_output/$RELEASE_DIR"
 
+for package_to_remove in $(echo "$PACKAGES_TO_REMOVE" | jq -r '.[]'); do
+  rm -rf packages/$package_to_remove
+done
+
 echo "$PRIVATE_YML" > config/private.yml
 
 for package in $(echo "$PACKAGES" | jq -r '.[]'); do
@@ -27,4 +31,6 @@ git add -A
 package_list=$(echo "$PACKAGES" | jq -r 'join(", ")')
 first_package=$(echo "$PACKAGES" | jq -r '.[0]')
 first_version=$(cat "$task_dir/golang-release/packages/$first_package/version")
-git commit -m "Update $package_list packages to $first_version from golang-release"
+git commit -m "Update $package_list packages to $first_version from golang-release
+
+Removed: $(echo "$PACKAGES_TO_REMOVE" | jq -r '. | join(", ")')"

--- a/ci/tasks/shared/bump-golang-package.yml
+++ b/ci/tasks/shared/bump-golang-package.yml
@@ -19,5 +19,6 @@ params:
   GIT_USER_NAME: CI Bot
   GIT_USER_EMAIL: bots@cloudfoundry.org
   PACKAGES:
+  PACKAGES_TO_REMOVE: []
   PRIVATE_YML:
   RELEASE_DIR:


### PR DESCRIPTION
This change makes it possible to specify packages to be removed when bumping a golang package.

This can be useful if a release has `golang-1.X-linux` installed and wishes to replace that package with a newer minor as in `golang-1.Y-linux`. In this case `PACKAGES_TO_REMOVE` would be an array containing to package to remove (`golang-1.X-linux`).
