### PR TITLE
CI: add GOPROXY support to bump-deps task

### DIFF
--- a/ci/tasks/shared/bump-deps.yml
+++ b/ci/tasks/shared/bump-deps.yml
@@ -20,5 +20,7 @@ params:
   GIT_USER_NAME: CI Bot
   GIT_USER_EMAIL: bots@cloudfoundry.org
   GO_PACKAGE:
+  GOPROXY:
+  GOSUMDB:
   DESIRED_GO_MAJOR_MINOR: # Defaults to the previous major.minor version to avoid breaking others who import the packages and are not yet on the latest version.
   SOURCE_PATH:


### PR DESCRIPTION
Also includes the ability to set GOSUMDB which may be used in conjuncction with GOPROXY.