### PR TITLE
CI: Use GHCR images for shared Concourse tasks

### DIFF
--- a/ci/tasks/shared/bump-deps.yml
+++ b/ci/tasks/shared/bump-deps.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: bosh/golang-release
+    repository: ghcr.io/cloudfoundry/bosh/golang-release
 
 inputs:
 - name: input_repo

--- a/ci/tasks/shared/bump-golang-package.yml
+++ b/ci/tasks/shared/bump-golang-package.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: bosh/golang-release
+    repository: ghcr.io/cloudfoundry/bosh/golang-release
 
 inputs:
 - name: input_repo

--- a/ci/tasks/shared/check-for-patched-cves.yml
+++ b/ci/tasks/shared/check-for-patched-cves.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: bosh/golang-release-security-scanner
+    repository: ghcr.io/cloudfoundry/bosh/golang-release-security-scanner
 
 inputs:
 - name: input_repo

--- a/ci/tasks/shared/check-for-updated-binary-version.yml
+++ b/ci/tasks/shared/check-for-updated-binary-version.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: bosh/golang-release
+    repository: ghcr.io/cloudfoundry/bosh/golang-release
 
 inputs:
 - name: previous_binary

--- a/ci/tasks/shared/check-for-updated-golang-package.yml
+++ b/ci/tasks/shared/check-for-updated-golang-package.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: bosh/golang-release-security-scanner
+    repository: ghcr.io/cloudfoundry/bosh/golang-release-security-scanner
 
 inputs:
 - name: input_repo

--- a/ci/tasks/shared/ensure-cve-checker-succeeded.yml
+++ b/ci/tasks/shared/ensure-cve-checker-succeeded.yml
@@ -4,7 +4,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: bosh/golang-release-security-scanner
+    repository: ghcr.io/cloudfoundry/bosh/golang-release-security-scanner
 
 inputs:
 - name: patched_cves


### PR DESCRIPTION
In 53654a9c6491a2b37904ead2799d39f27ee0b4b6, we switched from publishing CI images in Docker Hub to GHCR. However, we didn't update the shared community CI tasks to pull the images from their new location. This has resulted in the bump-deps task continuing to use an old image in Docker Hub that has golang 1.24 and 1.23, even though 1.23 has since been removed from the release.