### PR TITLE
Use multi substitution syntax for GOOS array

### DIFF
--- a/ci/tasks/shared/bump-deps.sh
+++ b/ci/tasks/shared/bump-deps.sh
@@ -24,7 +24,7 @@ if [ -z "${DESIRED_GO_MAJOR_MINOR}" ]; then
 fi
 
 # shellcheck disable=SC2206
-goos_array=(${GOOS_LIST/,/ })
+goos_array=(${GOOS_LIST//,/ })
 
 if (( ${#goos_array[@]} == 0 )); then
   echo "Error: GOOS_LIST was empty, at least one valid GOOS value must be provided"


### PR DESCRIPTION
With only a single slash, only the first "," is split.  You need to use double slashes to substitute every "," in the string.