### PR TITLE
ci: use noble cpi image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -119,6 +119,7 @@ resources:
   type: registry-image
   source:
     repository: ghcr.io/cloudfoundry/bosh/warden-cpi
+    tag: noble
     username: ((github_read_write_packages.username))
     password: ((github_read_write_packages.password))
 


### PR DESCRIPTION
* bosh-deployment defaults to noble now, so compiled releases for noble were failing to run on the old jammy based image/stemcell
* depends on https://github.com/cloudfoundry/bosh/pull/2643