### PR TITLE
use current bosh-warden-cpi-image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -125,7 +125,7 @@ resources:
 - name: stemcell
   type: bosh-io-stemcell
   source:
-    name: bosh-warden-boshlite-ubuntu-jammy-go_agent
+    name: bosh-warden-boshlite-ubuntu-noble
 
 - name: semver
   type: semver

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -118,9 +118,9 @@ resources:
 - name: bosh-warden-cpi-image
   type: registry-image
   source:
-    repository: bosh/warden-cpi
-    username: ((dockerhub_username))
-    password: ((dockerhub_password))
+    repository: ghcr.io/cloudfoundry/bosh/warden-cpi
+    username: ((github_read_write_packages.username))
+    password: ((github_read_write_packages.password))
 
 - name: stemcell
   type: bosh-io-stemcell

--- a/ci/tasks/test.sh
+++ b/ci/tasks/test.sh
@@ -12,7 +12,7 @@ source /tmp/local-bosh/director/env
 export STEMCELL_PATH="$build_dir/stemcell/stemcell.tgz"
 export STEMCELL_VERSION=$(cat stemcell/version)
 
-export OS="ubuntu-jammy"
+export OS="ubuntu-noble"
 export JOB_NAME="test"
 export VM_EXTENSIONS="[]"
 


### PR DESCRIPTION
* previously was still pulling from dockerhub, switched to ghcr
* also test with noble stemcell instead of jammy
* pipeline is flown https://bosh.ci.cloudfoundry.org/teams/main/pipelines/golang-release
* made a debug commit with the test changes and pointed the pipeline at my branch. It looks like the test itself succeeded in [this run](https://bosh.ci.cloudfoundry.org/teams/main/pipelines/golang-release/jobs/bump/builds/58) (I made the test fail intentionally at the end as to not trigger any following steps from a branch). These changes are reverted, pipeline points at main again.