### PR TITLE
ci: add notification for failed bumps

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -59,12 +59,13 @@ jobs:
         repository: release_repo
         tag: release_metadata/tag-name
   on_failure:
-  - put: slack-alert
-    params:
-      channel: '#bosh-private'
-      text: |
-        Build for $BUILD_PIPELINE_NAME failed!
-        View it here: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+    do:
+    - put: slack-alert
+      params:
+        channel: '#bosh-private'
+        text: |
+          Build for $BUILD_PIPELINE_NAME failed!
+          View it here: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
 - name: build-docker-image
   plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -16,6 +16,7 @@ jobs:
     - get: bosh-cli-image
     - get: bosh-warden-cpi-image
     - get: bosh-shared-ci
+    - get: slack-alert
   - task: bump
     file: golang-release/ci/tasks/bump.yml
     image: bosh-cli-image
@@ -60,6 +61,12 @@ jobs:
   on_failure:
   - put: gchat-notification
     params:
+      text: |
+        Build for $BUILD_PIPELINE_NAME failed!
+        View it here: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+  - put: slack-alert
+    params:
+      channel: '#bosh-private'
       text: |
         Build for $BUILD_PIPELINE_NAME failed!
         View it here: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
@@ -197,6 +204,11 @@ resources:
   source:
     url: ((gchat-webhook-dap-bosh-ecosystem-dev))
 
+- name: slack-alert
+  type: slack-notification
+  source:
+    url: ((slack_hook_url))
+
 resource_types:
 - name: dynamic-metalink
   type: docker-image
@@ -216,3 +228,9 @@ resource_types:
     tag: 0.0.1-SNAPSHOT
     username: ((docker.username))
     password: ((docker.password))
+
+- name: slack-notification
+  type: docker-image
+  source:
+    repository: cfcommunity/slack-notification-resource
+    tag:        latest

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -59,11 +59,6 @@ jobs:
         repository: release_repo
         tag: release_metadata/tag-name
   on_failure:
-  - put: gchat-notification
-    params:
-      text: |
-        Build for $BUILD_PIPELINE_NAME failed!
-        View it here: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
   - put: slack-alert
     params:
       channel: '#bosh-private'
@@ -199,11 +194,6 @@ resources:
     - go*.windows-amd64.zip
     - go*.darwin-amd64.tar.gz
 
-- name: gchat-notification
-  type: google-chat-notify-resource
-  source:
-    url: ((gchat-webhook-dap-bosh-ecosystem-dev))
-
 - name: slack-alert
   type: slack-notification
   source:
@@ -220,14 +210,6 @@ resource_types:
   source:
     repository: concourse/semver-resource
     tag: 1.6
-
-- name: google-chat-notify-resource
-  type: registry-image
-  source:
-    repository: springio/google-chat-notify-resource
-    tag: 0.0.1-SNAPSHOT
-    username: ((docker.username))
-    password: ((docker.password))
 
 - name: slack-notification
   type: docker-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -57,6 +57,12 @@ jobs:
         rebase: true
         repository: release_repo
         tag: release_metadata/tag-name
+  on_failure:
+  - put: gchat-notification
+    params:
+      text: |
+        Build for $BUILD_PIPELINE_NAME failed!
+        View it here: $ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
 - name: build-docker-image
   plan:
@@ -186,6 +192,11 @@ resources:
     - go*.windows-amd64.zip
     - go*.darwin-amd64.tar.gz
 
+- name: gchat-notification
+  type: google-chat-notify-resource
+  source:
+    url: ((gchat-webhook-dap-bosh-ecosystem-dev))
+
 resource_types:
 - name: dynamic-metalink
   type: docker-image
@@ -197,3 +208,11 @@ resource_types:
   source:
     repository: concourse/semver-resource
     tag: 1.6
+
+- name: google-chat-notify-resource
+  type: registry-image
+  source:
+    repository: springio/google-chat-notify-resource
+    tag: 0.0.1-SNAPSHOT
+    username: ((docker.username))
+    password: ((docker.password))


### PR DESCRIPTION
* many teams rely on this package, so we'd like to be more on top of fixing failures
* sends a message to the #bosh-private slack channel
* pipeline is set already: https://bosh.ci.cloudfoundry.org/teams/main/pipelines/golang-release